### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ namespace DijkstraAlgorithm
 }
 ```
 
-Run the demo on repl.it https://repl.it/@AmieDD/C-Shortest-Path-Dijkstra-Algorithm
+[![Run on Repl.it](https://repl.it/badge/github/AmieDD/Dijkstra-Algorithm)](https://repl.it/github/AmieDD/Dijkstra-Algorithm)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AmieDD/Dijkstra-Algorithm).